### PR TITLE
Workaround for `OnPreviewKeyDown` on MacOS

### DIFF
--- a/TAS.Avalonia/Controls/EditorControl.axaml.cs
+++ b/TAS.Avalonia/Controls/EditorControl.axaml.cs
@@ -50,6 +50,17 @@ public partial class EditorControl : UserControl {
         editor.TextArea.ActiveInputHandler = new TASInputHandler(editor.TextArea);
         editor.TextArea.PushStackedInputHandler(new TASStackedInputHandler(editor.TextArea));
         editor.TextArea.Caret.PositionChanged += (_, _) => CaretPosition = editor.TextArea.Caret.Position;
+        editor.TextArea.TextEntering += (_, e) => {
+            if (e.Text.Length != 1 || e.Text[0] is not >= 'a' and <= 'z' or >= 'A' and <= 'Z') return;
+
+            var key = e.Text[0] switch {
+                >= 'a' and <= 'z' => e.Text[0] - 'a' + Key.A,
+                >= 'A' and <= 'Z' => e.Text[0] - 'A' + Key.A,
+                _ => Key.None,
+            };
+
+            e.Handled = TASStackedInputHandler.HandleActionInput(editor.TextArea, key);
+        };
         PropertyChanged += (_, e) => {
             if (e.Property == CaretPositionProperty) {
                 editor.TextArea.Caret.Position = (TextViewPosition) e.NewValue!;

--- a/TAS.Avalonia/Extensions.cs
+++ b/TAS.Avalonia/Extensions.cs
@@ -36,7 +36,8 @@ public static class Extensions {
     public static bool ValidForAction(this KeyGesture self) =>
         self.KeyModifiers == KeyModifiers.None && self.Key.NumberForKey() >= 0 ||
         self.KeyModifiers is KeyModifiers.None or KeyModifiers.Shift && self.Key.ActionForKey() != TASAction.None ||
-        self.KeyModifiers is KeyModifiers.None && self.Key is Key.OemPeriod or Key.OemComma;
+        self.KeyModifiers is KeyModifiers.None && self.Key is Key.OemPeriod or Key.OemComma ||
+        self.KeyModifiers is KeyModifiers.None or KeyModifiers.Shift && self.Key is >= Key.A and <= Key.Z;
 
     public static int NumberForKey(this Key self) =>
         self switch {


### PR DESCRIPTION
Workaround for the issue of `OnPreviewKeyDown` sometimes not being fired on MacOS.
Removed the hardcoded Shift+3 comment, however that hotkey didn't work on all platforms + it should probably be implemented in the `TASEditingCommandHandler`.