### PR TITLE
Show game info in Studio

### DIFF
--- a/TAS.Avalonia/App.axaml
+++ b/TAS.Avalonia/App.axaml
@@ -12,10 +12,27 @@
     <Application.Styles>
         <FluentTheme />
         <StyleInclude Source="avares://AvaloniaEdit/Themes/Fluent/AvaloniaEdit.xaml" />
+
+        <Styles>
+            <Styles.Resources>
+                <ResourceDictionary>
+                    <ResourceDictionary.ThemeDictionaries>
+                        <ResourceDictionary x:Key="Light">
+                            <!-- TODO -->
+                        </ResourceDictionary>
+                        <ResourceDictionary x:Key="Dark">
+                            <SolidColorBrush x:Key="Background1Brush">#000000</SolidColorBrush>
+                            <SolidColorBrush x:Key="Background2Brush">#111111</SolidColorBrush>
+                            <SolidColorBrush x:Key="Background3Brush">#333333</SolidColorBrush>
+                        </ResourceDictionary>
+                    </ResourceDictionary.ThemeDictionaries>
+                </ResourceDictionary>
+            </Styles.Resources>
+        </Styles>
     </Application.Styles>
 
     <Application.Resources>
-        <FontFamily x:Key="CodeFontFamily">Cascadia Code,Consolas,Menlo,Monospace</FontFamily>
+        <FontFamily x:Key="CodeFontFamily">Jetbrinas Mono,Cascadia Code,Consolas,Menlo,Monospace</FontFamily>
         <converters:NativeMenuConverter x:Key="NativeMenuConverter" />
         <converters:MenuConverter x:Key="MenuConverter" />
         <converters:ContextMenuConverter x:Key="ContextMenuConverter" />

--- a/TAS.Avalonia/Services/SettingsService.cs
+++ b/TAS.Avalonia/Services/SettingsService.cs
@@ -17,6 +17,11 @@ public class SettingsService : ReactiveObject {
     }
     public string LastOpenFileName => LastOpenFilePath == null ? null : Path.GetFileName(LastOpenFilePath);
 
+    public bool GameInfoVisible {
+        get => _settings.GameInfoVisible;
+        set => this.RaiseAndSetIfChanged(ref _settings.GameInfoVisible, value);
+    }
+
     public SettingsService() {
         var dataDir = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
         _settingsFilePath = Path.Combine(dataDir, AppDataDirectory, DefaultSettingsFileName);
@@ -62,5 +67,7 @@ public class SettingsService : ReactiveObject {
     [Serializable]
     public class Settings {
         public string LastOpenFilePath = "";
+
+        public bool GameInfoVisible = true;
     }
 }

--- a/TAS.Avalonia/TAS.Avalonia.csproj
+++ b/TAS.Avalonia/TAS.Avalonia.csproj
@@ -53,7 +53,7 @@
     <Reference Include="libs/AvaloniaEdit.TextMate.dll" />
 <!--    <PackageReference Include="Avalonia.AvaloniaEdit" Version="11.0.0" />-->
 <!--    <PackageReference Include="AvaloniaEdit.TextMate" Version="11.0.0" />-->
-    
+
     <PackageReference Include="TextMateSharp.Grammars" Version="1.0.55" />
     <PackageReference Include="ReactiveUI" Version="18.3.1" />
     <PackageReference Include="JetBrains.Annotations" Version="2022.3.1" />

--- a/TAS.Avalonia/ViewModels/MainWindowViewModel.cs
+++ b/TAS.Avalonia/ViewModels/MainWindowViewModel.cs
@@ -55,6 +55,12 @@ public class MainWindowViewModel : ViewModelBase {
     private readonly ObservableAsPropertyHelper<string> _windowTitle;
     public string WindowTitle => _windowTitle.Value;
 
+    private string _statusText = "Searching...";
+    public string StatusText {
+        get => _statusText;
+        set => this.RaiseAndSetIfChanged(ref _statusText, value);
+    }
+
     private TASDocument _document;
     public TASDocument Document {
         get => _document;
@@ -88,6 +94,10 @@ public class MainWindowViewModel : ViewModelBase {
         _windowTitle = this.WhenAnyValue(x => x.Document.FileName, x => x.Document.Dirty, (path, dirty) => Tuple.Create(path, dirty))
                            .Select(t => $"TAS Studio{(t.Item1 != null ? $" - {(t.Item2 ? "*" : "")}{t.Item1}" : "")}")
                            .ToProperty(this, nameof(WindowTitle));
+        _celesteService.Server.StateUpdated += state => {
+            Console.WriteLine(state.GameInfo);
+            StatusText = state.GameInfo;
+        };
 
         // File
         NewFileCommand = ReactiveCommand.Create(NewFile);

--- a/TAS.Avalonia/Views/MainWindow.axaml
+++ b/TAS.Avalonia/Views/MainWindow.axaml
@@ -22,7 +22,7 @@
               IsVisible="{Binding MenuVisible}"
               ItemsSource="{Binding MainMenu, Converter={StaticResource MenuConverter}}" />
 
-        <StackPanel Name="StatusBar" Background="{DynamicResource Background2Brush}" DockPanel.Dock="Bottom" Orientation="Horizontal">
+        <StackPanel IsVisible="{Binding GameInfoVisible}" Name="StatusBar" Background="{DynamicResource Background2Brush}" DockPanel.Dock="Bottom" Orientation="Horizontal">
             <TextBlock Foreground="White" Text="{Binding StatusText}"
                        FontSize="12" FontFamily="Jetbrains Mono"
                        Margin="5 5 5 0" VerticalAlignment="Center" />

--- a/TAS.Avalonia/Views/MainWindow.axaml
+++ b/TAS.Avalonia/Views/MainWindow.axaml
@@ -21,6 +21,13 @@
         <Menu DockPanel.Dock="Top"
               IsVisible="{Binding MenuVisible}"
               ItemsSource="{Binding MainMenu, Converter={StaticResource MenuConverter}}" />
+
+        <StackPanel Name="StatusBar" Background="{DynamicResource Background2Brush}" DockPanel.Dock="Bottom" Orientation="Horizontal">
+            <TextBlock Foreground="White" Text="{Binding StatusText}"
+                       FontSize="12" FontFamily="Jetbrains Mono"
+                       Margin="5 5 5 0" VerticalAlignment="Center" />
+        </StackPanel>
+
         <controls:EditorControl x:Name="editor" Document="{Binding Document}"
                                 CaretPosition="{Binding CaretPosition, Mode=TwoWay}"
                                 ContextMenu="{Binding EditorContextMenu, Converter={StaticResource ContextMenuConverter}}" />


### PR DESCRIPTION
Adds a toggleable box for the in-game info. Could probably add custom info editing to there later. It being resizable might also make sense.

#17 needs to be merged first, since I based this of that one.