### PR TITLE
Automatically "reload" TAS file

### DIFF
--- a/TAS.Avalonia/Communication/StudioCommunicationServer.cs
+++ b/TAS.Avalonia/Communication/StudioCommunicationServer.cs
@@ -7,9 +7,11 @@ namespace TAS.Avalonia.Communication;
 public class StudioCommunicationServer : StudioCommunicationBase {
     public event Action<StudioInfo> StateUpdated;
     public event Action<Dictionary<HotkeyID, List<Keys>>> BindingsUpdated;
+    public event Action<Dictionary<int, string>> LinesUpdated;
 
     protected virtual void OnStateUpdated(StudioInfo obj) => StateUpdated?.Invoke(obj);
     protected virtual void OnBindingsUpdated(Dictionary<HotkeyID, List<Keys>> obj) => BindingsUpdated?.Invoke(obj);
+    protected virtual void OnLinesUpdated(Dictionary<int, string> lines) => LinesUpdated?.Invoke(lines);
 
     private string _returnData;
 
@@ -99,7 +101,8 @@ public class StudioCommunicationServer : StudioCommunicationBase {
     }
 
     private void ProcessUpdateLines(byte[] data) {
-        // Dictionary<int, string> updateLines = BinaryFormatterHelper.FromByteArray<Dictionary<int, string>>(data);
+        Dictionary<int, string> updateLines = BinaryFormatterHelper.FromByteArray<Dictionary<int, string>>(data);
+        OnLinesUpdated(updateLines);
         // CommunicationWrapper.UpdateLines(updateLines);
     }
 

--- a/TAS.Avalonia/Controls/EditorControl.axaml.cs
+++ b/TAS.Avalonia/Controls/EditorControl.axaml.cs
@@ -67,8 +67,10 @@ public partial class EditorControl : UserControl {
         };
 
         int prevLine = 0;
-        (Application.Current as App).CelesteService.Server.StateUpdated += state => {
-            if (state.CurrentLine == prevLine) return;
+        (Application.Current as App)!.CelesteService.Server.StateUpdated += state => {
+            if (state.CurrentLine == -1 || state.CurrentLine == prevLine) return;
+            prevLine = state.CurrentLine;
+
             Dispatcher.UIThread.InvokeAsync(() =>
             {
                 const int LinesBelow = 3;
@@ -99,7 +101,6 @@ public partial class EditorControl : UserControl {
                     view.MakeVisible(new Rect(0, lineTop, 0, lineBottom - lineTop));
                 }
             });
-            prevLine = state.CurrentLine;
         };
     }
 


### PR DESCRIPTION
This handles the `UpdateLines` message, so that `ChapterTime`, `RecordCount`, etc are automatically updated.
Also fixes a bug where the caret would get reset when stopping the TAS.